### PR TITLE
Bug 887

### DIFF
--- a/src/luwak_wm_file.erl
+++ b/src/luwak_wm_file.erl
@@ -212,6 +212,8 @@ malformed_request(RD, Ctx) when Ctx#ctx.method =:= 'POST'
         _ ->
             {false, RD, Ctx}
     end;
+malformed_request(RD, Ctx) when Ctx#ctx.key =:= undefined ->
+    {false, RD, Ctx};
 malformed_request(RD, Ctx) ->
     HCtx = ensure_handle(Ctx),
     case HCtx#ctx.handle of


### PR DESCRIPTION
A patch to address Bug 887.

After patching this it made me realize /luwak will look a lot like a bucket to the unwitting user, but isn't a bucket.  It's a pseudo bucket, if you will.  I just wonder if it's something that could confuse users or if that's a implementation detail they shouldn't be worried about.

Furthermore, the PUT verb is currently not supported on this resource but it would probably be a logical way to change the default block size and other properties.

Finally, the block size returned could actually be incorrect because of my recent patch to allow a configurable default.  I'll write up a new bug and probably do the fix while I'm at it.
