### PR TITLE
Bug 1026

### DIFF
--- a/include/luwak.hrl
+++ b/include/luwak.hrl
@@ -10,6 +10,11 @@
 
 -define(fmt(S, As), lists:flatten(io_lib:format(S, As))).
 
+-define(get_default_block_size,
+        app_helper:get_env(luwak,
+                           default_block_size,
+                           ?BLOCK_DEFAULT)).
+
 -record(split, {head=[], midhead=[], middle=[], midtail=[], tail=[]}).
 
 -ifndef(EUNIT_HRL).

--- a/src/luwak_file.erl
+++ b/src/luwak_file.erl
@@ -37,10 +37,8 @@ create(Riak, Name, Attributes) when is_binary(Name) ->
 %%                                   checksum of the most recent write request
 %%                                   as a property of the filehandle.
 create(Riak, Name, Properties, Attributes) when is_binary(Name) ->
-    DefaultBlockSize = app_helper:get_env(luwak,
-                                          default_block_size,
-                                          ?BLOCK_DEFAULT),
-    BlockSize = proplists:get_value(block_size, Properties, DefaultBlockSize),
+    BlockSize = proplists:get_value(block_size, Properties,
+                                    ?get_default_block_size),
     Order = proplists:get_value(tree_order, Properties, ?ORDER_DEFAULT),
     Checksumming = proplists:get_value(checksumming, Properties, false),
     if

--- a/src/luwak_wm_file.erl
+++ b/src/luwak_wm_file.erl
@@ -417,7 +417,7 @@ produce_toplevel_body(RD, Ctx=#ctx{client=C}) ->
             _ ->
                 Props = [{<<"o_bucket">>, ?O_BUCKET},
                          {<<"n_bucket">>, ?N_BUCKET},
-                         {<<"block_default">>, ?BLOCK_DEFAULT}],
+                         {<<"block_default">>, ?get_default_block_size}],
                 [{?JSON_PROPS, {struct, Props}}]
         end,
     KeyPart =
@@ -503,7 +503,8 @@ accept_doc_body(RD, Ctx=#ctx{key=K, client=C}) ->
 
 accept_streambody(RD, #ctx{handle={ok, H}, client=C}) ->
     Stream = luwak_put_stream:start_link(C, H, 0, 1000),
-    accept_streambody1(Stream, 0, wrq:stream_req_body(RD, ?BLOCK_DEFAULT)).
+    accept_streambody1(Stream, 0,
+                       wrq:stream_req_body(RD, ?get_default_block_size)).
 
 accept_streambody1(Stream, Count0, {Data, Next}) ->
     Count = Count0+size(Data),


### PR DESCRIPTION
This is a patch to address bug 1026.

Is the lowercase macro name idiomatic Erlang?  I figured since fmt was lowercase I'd follow suit but it looks weird to me.

Also, should accept_streambody1 be tied to the default block size?
