### PR TITLE
Add riak_pipe dependency; needed for riak_kv to start.

### DIFF
--- a/test/test_helper.erl
+++ b/test/test_helper.erl
@@ -15,6 +15,7 @@
          erlang_js,
          skerl,
          bitcask,
+         riak_pipe,
          riak_kv]).
 
 riak_test(Fun) ->


### PR DESCRIPTION
Fixes this:

```
luwak_tree_tests: create_and_append_test...*failed*
::throw:{"failed to start",riak_kv,{error,{not_started,riak_pipe}}}  in function test_helper:ensure_started/1
  in call from test_helper:load_and_start_apps/1  in call from test_helper:riak_test/1
```
