### PR TITLE
Jdm 1.0.3 eunit fixes

### DIFF
--- a/ebin/luwak.app
+++ b/ebin/luwak.app
@@ -20,7 +20,8 @@
                   stdlib,
                   skerl,
                   webmachine,
-                  riak_kv
+                  riak_kv,
+                  erlang_js
                  ]},
   {mod, { luwak_app, []}},
   {env, []}

--- a/test/test_helper.erl
+++ b/test/test_helper.erl
@@ -52,8 +52,11 @@ start_riak() ->
     LogFile = "./luwak-eunit-sasl.log",
     ok = application:set_env(sasl, sasl_error_logger, {file, LogFile}),
     application:start(sasl),
+    application:start(lager),
     error_logger:delete_report_handler(sasl_report_tty_h),
-    load_and_start_apps(?APPS).
+    load_and_start_apps(?APPS),
+    riak_core:wait_for_service(riak_kv),
+    riak_core:wait_for_service(riak_pipe).
 
 stop_riak() ->
     case whereis(riak_core_ring_manager) of


### PR DESCRIPTION
Made the luwak tests wait for riak_kv and riak_pipe services.

1.0.3 changed services to be marked up after primary vnodes are initialized and running, not after application was started.
